### PR TITLE
Added Modifier None to create a hotkey without modifier

### DIFF
--- a/hotkey.go
+++ b/hotkey.go
@@ -15,6 +15,7 @@ type Modifier uint32
 
 // These are all members of hotkey.Modifier.
 const (
+	None  Modifier = hotkey_win.MOD_NONE
 	Alt   Modifier = hotkey_win.MOD_ALT
 	Ctrl  Modifier = hotkey_win.MOD_CONTROL
 	Shift Modifier = hotkey_win.MOD_SHIFT

--- a/win/consts.go
+++ b/win/consts.go
@@ -5,7 +5,7 @@
 package hotkey_win
 
 const (
-	MOND_NONE   = 0
+	MOD_NONE    = 0
 	MOD_ALT     = 1
 	MOD_CONTROL = 2
 	MOD_SHIFT   = 4

--- a/win/consts.go
+++ b/win/consts.go
@@ -5,6 +5,7 @@
 package hotkey_win
 
 const (
+	MOND_NONE   = 0
 	MOD_ALT     = 1
 	MOD_CONTROL = 2
 	MOD_SHIFT   = 4


### PR DESCRIPTION
using hotkey.None as modifier it is now possible to create a hook for any key without using a modifier.